### PR TITLE
events.lua: Fix bug with unexpected Classes on TBC.

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -3405,29 +3405,35 @@ do -- UPDATE_UI_WIDGET
 	}
 	local _e = Enum.UIWidgetVisualizationType
 	local _w = C_UIWidgetManager
-	local _widgetHandlers = {
-		[_e.IconAndText] = _w.GetIconAndTextWidgetVisualizationInfo,
-		[_e.CaptureBar] = _w.GetCaptureBarWidgetVisualizationInfo,
-		[_e.StatusBar] = _w.GetStatusBarWidgetVisualizationInfo,
-		[_e.DoubleStatusBar] = _w.GetDoubleStatusBarWidgetVisualizationInfo,
-		[_e.IconTextAndBackground] = _w.GetIconTextAndBackgroundWidgetVisualizationInfo,
-		[_e.DoubleIconAndText] = _w.GetDoubleIconAndTextWidgetVisualizationInfo,
-		[_e.StackedResourceTracker] = _w.GetStackedResourceTrackerWidgetVisualizationInfo,
-		[_e.IconTextAndCurrencies] = _w.GetIconTextAndCurrenciesWidgetVisualizationInfo,
-		[_e.TextWithState] = _w.GetTextWithStateWidgetVisualizationInfo,
-		[_e.HorizontalCurrencies] = _w.GetHorizontalCurrenciesWidgetVisualizationInfo,
-		[_e.BulletTextList] = _w.GetBulletTextListWidgetVisualizationInfo,
-		[_e.ScenarioHeaderCurrenciesAndBackground] = _w.GetScenarioHeaderCurrenciesAndBackgroundWidgetVisualizationInfo,
-		[_e.TextureAndText] = _w.GetTextureAndTextVisualizationInfo,
-		[_e.SpellDisplay] = _w.GetSpellDisplayVisualizationInfo,
-		[_e.DoubleStateIconRow] = _w.GetDoubleStateIconRowVisualizationInfo,
-		[_e.TextureAndTextRow] = _w.GetTextureAndTextRowVisualizationInfo,
-		[_e.ZoneControl] = _w.GetZoneControlVisualizationInfo,
-		[_e.CaptureZone] = _w.GetCaptureZoneVisualizationInfo,
-		[_e.TextureWithAnimation] = _w.GetTextureWithAnimationVisualizationInfo,
-		[_e.DiscreteProgressSteps] = _w.GetDiscreteProgressStepsVisualizationInfo,
-		[_e.ScenarioHeaderTimer] = _w.GetScenarioHeaderTimerWidgetVisualizationInfo,
+	local _handlers = {
+		["IconAndText"] = "GetIconAndTextWidgetVisualizationInfo",
+		["CaptureBar"] = "GetCaptureBarWidgetVisualizationInfo",
+		["StatusBar"] = "GetStatusBarWidgetVisualizationInfo",
+		["DoubleStatusBar"] = "GetDoubleStatusBarWidgetVisualizationInfo",
+		["IconTextAndBackground"] = "GetIconTextAndBackgroundWidgetVisualizationInfo",
+		["DoubleIconAndText"] = "GetDoubleIconAndTextWidgetVisualizationInfo",
+		["StackedResourceTracker"] = "GetStackedResourceTrackerWidgetVisualizationInfo",
+		["IconTextAndCurrencies"] = "GetIconTextAndCurrenciesWidgetVisualizationInfo",
+		["TextWithState"] = "GetTextWithStateWidgetVisualizationInfo",
+		["HorizontalCurrencies"] = "GetHorizontalCurrenciesWidgetVisualizationInfo",
+		["BulletTextList"] = "GetBulletTextListWidgetVisualizationInfo",
+		["ScenarioHeaderCurrenciesAndBackground"] = "GetScenarioHeaderCurrenciesAndBackgroundWidgetVisualizationInfo",
+		["TextureAndText"] = "GetTextureAndTextVisualizationInfo",
+		["SpellDisplay"] = "GetSpellDisplayVisualizationInfo",
+		["DoubleStateIconRow"] = "GetDoubleStateIconRowVisualizationInfo",
+		["TextureAndTextRow"] = "GetTextureAndTextRowVisualizationInfo",
+		["ZoneControl"] = "GetZoneControlVisualizationInfo",
+		["CaptureZone"] = "GetCaptureZoneVisualizationInfo",
+		["TextureWithAnimation"] = "GetTextureWithAnimationVisualizationInfo",
+		["DiscreteProgressSteps"] = "GetDiscreteProgressStepsVisualizationInfo",
+		["ScenarioHeaderTimer"] = "GetScenarioHeaderTimerWidgetVisualizationInfo",
 	}
+	local _widgetHandlers = {}
+	for k, v in pairs(_handlers) do
+		if _e[k] and _w[v] then
+			_widgetHandlers[_e[k]] = _w[v]
+		end
+	end
 	local function tableToString(key, t)
 		local str = sformat("%s", key)
 		for k,v in pairs(t) do

--- a/events.lua
+++ b/events.lua
@@ -1375,7 +1375,9 @@ do -- COMBAT_LOG_EVENT_UNFILTERED
 	local classColors = {}
 	for i = 1, GetNumClasses() do
 		local _, className = GetClassInfo(i)
-		classColors[i] = RAID_CLASS_COLORS[className].colorStr
+		if className and RAID_CLASS_COLORS[className] then
+			classColors[i] = RAID_CLASS_COLORS[className].colorStr
+		end
 	end
 	local function formatClassColor(id, txt)
 		if not id or not iEETConfig.classColors then return txt end


### PR DESCRIPTION
On TBC GetNumClasses() returns 11, but the expansion only has 9
classes. The code goes on to call GetClassInfo() which returns
nil for classIndex when it does not exist in the game.
i.e 6 - Death Knight, 10 - Monk, etc. It then tries
to index RAID_CLASS_COLORS with nil which of course causes an error.